### PR TITLE
Tighter Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,9 @@ PATH
   remote: .
   specs:
     mogbak (0.1.3)
-      activerecord-import (>= 0.2.9)
-      gli (>= 1.5.1)
+      activerecord (~> 3.2.19)
+      activerecord-import (~> 0.2.9)
+      gli (~> 1.5.1)
       mogilefs-client (>= 3.1.1)
       mysql2 (>= 0.3.11)
       sqlite3 (>= 1.3.5)


### PR DESCRIPTION
Regarding #18, I've tightened up the GLI import, and also because ActiveRecord 4.0 seems incompatible, I've pinned to the latest in the 3.2 series of ActiveRecord.

(I'm not really a rubyist, sorry if there's an obvious mistake that I've made).